### PR TITLE
Fixed setup.py installation problem by adding numpy and include_dirs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python
 
+import numpy
 from setuptools import setup
 from c2s import __version__
+
 try:
 	from Cython.Build import cythonize
 except:
@@ -34,4 +36,5 @@ setup(
 		'Operating System :: OS Independent',
 		'Programming Language :: Python'),
 	ext_modules=cythonize("c2s/roc.pyx"),
+    include_dirs=[numpy.get_include()]
 )


### PR DESCRIPTION
I fixed `numpy/arrayobject.h` problem by adding few lines in `setup.py`.

See recommendation from http://stackoverflow.com/questions/14657375/cython-fatal-error-numpy-arrayobject-h-no-such-file-or-directory

After I fixed that. Now, in C2S directory, I can do:

``` python
python setup.py build
sudo python setup.py install
```

Moreover, you may consider adding more installation in C2S.
