### PR TITLE
Update broken link to benchmarking spike rate inference paper

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ easier especially if you are planning to use Windows or Mac OS.
 If you use our code in your research, please cite the following paper:
 
 L. Theis, P. Berens, E. Froudarakis, J. Reimer, M. Roman-Roson, T. Baden, T. Euler, A. S. Tolias, et al.  
-[Benchmarking spike rate inference in population calcium imaging](http://bethgelab.org/publications/127/)  
+[Benchmarking spike rate inference in population calcium imaging](https://bethgelab.org/publication/2016_05_theis/)  
 Neuron, 90(3), 471-482, 2016
 
 The default model was trained on many datasets (together containing roughly 110,000 spikes) from


### PR DESCRIPTION
The previous link http://bethgelab.org/publications/127/ to the publication of "Benchmarking spike rate inference in population calcium imaging" returns "404 Not Found".
I updated the link to https://bethgelab.org/publication/2016_05_theis/ (it's the same website, probably the url schema of it changed).